### PR TITLE
[CHORE] 17버전에 호환되도록 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,14 @@ plugins {
 }
 
 group = 'io.github.coli-geonwoo'
-version = '1.0.0'
+version = '1.0.1'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 
 tasks.withType(Javadoc) {
     options {
@@ -26,7 +33,7 @@ mavenPublishing {
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
     signAllPublications()
 
-    coordinates("io.github.coli-geonwoo", "odsay-utils", "1.0.0") // 네임 스페이스, 라이브러리 이름, 버전 순서로 작성
+    coordinates("io.github.coli-geonwoo", "odsay-utils", "1.0.1") // 네임 스페이스, 라이브러리 이름, 버전 순서로 작성
 
     // POM 설정
     pom {
@@ -83,6 +90,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     compileOnly 'org.projectlombok:lombok'
 
+    testImplementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,8 @@
+#maven central account ?? ??
+mavenCentralUsername=
+mavenCentralPassword=
+
+signing.keyId=
+signing.password=
+signing.secretKeyRingFile=
+


### PR DESCRIPTION
close #4 
close #5 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 프로젝트 버전이 1.0.0에서 1.0.1로 업데이트되었습니다.
  * Java 17 도구 체인이 추가되었습니다.
  * 테스트 환경에서 웹 관련 테스트를 지원하기 위해 spring-boot-starter-web이 추가되었습니다.
  * Maven Central 배포를 위한 인증 및 서명 정보를 위한 gradle.properties 파일이 도입되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->